### PR TITLE
Source maps

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -3,9 +3,12 @@ var compiledModules = require('broccoli-es6-module-transpiler');
 var uglify = require('broccoli-uglify-js');
 var find = stew.find;
 var env  = stew.env;
+var map  = stew.map;
 var rename = stew.rename;
 var mv = stew.mv;
 var path = require('path');
+var version = require('git-repo-version');
+var fs = require('fs');
 
 var lib       = find('lib');
 var tests     = find('tests');
@@ -33,8 +36,16 @@ env('production', function() {
   ]);
 });
 
+function prependLicense(content, path) {
+  var license = fs.readFileSync('./config/versionTemplate.txt').toString().replace(/VERSION_PLACEHOLDER_STRING/, version());
+
+  content.prepend(license);
+
+  return content;
+}
+
 module.exports = find([
-  dagMap,
+  map(dagMap, prependLicense),
   tests,
   testIndex,
   mv(qunit, 'tests')

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "broccoli-uglify-js": "^0.1.3",
     "ember-cli": "^0.2.0",
     "es6-module-transpiler-amd-formatter": "^0.3.0",
+    "git-repo-version": "^0.2.0",
     "qunitjs": "^1.17.1"
   }
 }


### PR DESCRIPTION
once https://github.com/stefanpenner/broccoli-stew/pull/68 will be
pulled back in, this change will allow us to update source maps as well.

in this particular case, prepend licence templates to all the files.